### PR TITLE
Translation string formatted incorrectly. Update umc-core.sp.

### DIFF
--- a/addons/sourcemod/scripting/umc-core.sp
+++ b/addons/sourcemod/scripting/umc-core.sp
@@ -3021,7 +3021,7 @@ DisplayTierMessage(timeleft)
 {
 	decl String:notification[10];
 	GetConVarString(cvar_vote_tierdisplay, notification, sizeof(notification));
-	PrintCenterTextAll("%T", "Another Vote", timeleft);
+	PrintCenterTextAll("%t", "Another Vote", timeleft);
 	//DisplayServerMessage(notification, "%t", "Another Vote", timeleft);
 }
 


### PR DESCRIPTION
Exception reported: Translation string formatted incorrectly - missing at least 1 parameters (arg 4).