### PR TITLE
Fixed erroneous BuildMapVoteItems call with transposed parameters.

### DIFF
--- a/addons/sourcemod/scripting/umc-core.sp
+++ b/addons/sourcemod/scripting/umc-core.sp
@@ -3926,8 +3926,8 @@ public Action:Handle_TieredVoteTimer(Handle:timer, Handle:pack)
 	new Handle:options = CreateArray();
 
 	new UMC_BuildOptionsError:error = BuildMapVoteItems(
-		vM, options, stored_mapcycle,
-		tieredKV, stored_scramble, false,
+		vM, options, tieredKV,
+		stored_mapcycle, stored_scramble, false,
 		false, stored_ignoredupes,
 		stored_strictnoms, true, stored_exclude);
 


### PR DESCRIPTION
Fixed issue #2 from ArcalaAlien's fork source.  This was caused by parameters 3 and 4 of the BuildMapVoteItems call on line 3928 being swapped.

See: function signature at line 2110 and compare.